### PR TITLE
Update OpenLineage.csproj

### DIFF
--- a/sparklin/OpenLineage/OpenLineage/OpenLineage.csproj
+++ b/sparklin/OpenLineage/OpenLineage/OpenLineage.csproj
@@ -1,15 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Functions">
+
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <UserSecretsId>c5590014-6f5a-416a-9f64-80d4ed0332a8</UserSecretsId>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
   </ItemGroup>
+
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -19,4 +22,5 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
### 🚀 Upgrade Azure Functions App to .NET 6 and Functions v4

**Changes made:**
- TargetFramework upgraded from `netcoreapp3.1` to `net6.0`
- Functions SDK version bumped to `v4.1.1`
- `AzureFunctionsVersion` updated to `v4`
- NuGet packages updated:
  - `Azure.Storage.Blobs` ➜ 12.19.0
  - `Microsoft.ApplicationInsights.WorkerService` ➜ 2.21.0
- App Settings (in Azure Portal) must include:
  - `FUNCTIONS_EXTENSION_VERSION=~4`
  - `FUNCTIONS_WORKER_RUNTIME=dotnet`

**Why:**  
.NET Core 3.1 and Azure Functions v3 are out of support. This aligns the repo with current Azure best practices and unlocks long-term platform compatibility.

---